### PR TITLE
Update for Django 1.5(beta1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ python:
   - 2.6
   - 2.7
 env:
-  - DJANGO_VERSION=1.3.1
-  - DJANGO_VERSION=1.4
+  - DJANGO_VERSION='Django==1.3.1'
+  - DJANGO_VERSION='Django==1.4'
+  - DJANGO_VERSION='https://www.djangoproject.com/download/1.5b1/tarball/'
 install:
-  - pip install Django==$DJANGO_VERSION --use-mirrors
+  - pip install $DJANGO_VERSION --use-mirrors
   - pip install -r requirements/travis-ci.txt
   - pip install -q -e . --use-mirrors
 script:

--- a/refinery/filters.py
+++ b/refinery/filters.py
@@ -15,7 +15,7 @@ __all__ = [
     'OpenRangeNumericFilter', 'OpenRangeDateFilter', 'OpenRangeTimeFilter',
 ]
 
-LOOKUP_TYPES = sorted(QUERY_TERMS.keys())
+LOOKUP_TYPES = sorted(QUERY_TERMS)
 
 
 class Filter(object):

--- a/refinery/filtertool.py
+++ b/refinery/filtertool.py
@@ -6,7 +6,12 @@ from django.db import models
 from django.db.models import Q
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.related import RelatedObject
-from django.db.models.sql.constants import QUERY_TERMS, LOOKUP_SEP
+try:
+    from django.db.models.constants import LOOKUP_SEP
+except ImportError:
+    # Django < 1.5
+    from django.db.models.sql.constants import LOOKUP_SEP
+from django.db.models.sql.constants import QUERY_TERMS
 from django.utils.datastructures import SortedDict
 from django.utils.text import capfirst
 
@@ -70,7 +75,7 @@ def filters_for_model(model, fields=None, exclude=None, filter_for_field=None):
     for f in fields:
         if exclude is not None and f in exclude:
             continue
-        if f.split(LOOKUP_SEP)[-1] in QUERY_TERMS.keys():
+        if f.split(LOOKUP_SEP)[-1] in QUERY_TERMS:
             lookup_type = f.split(LOOKUP_SEP)[-1]
             f = LOOKUP_SEP.join(f.split(LOOKUP_SEP)[:-1])
         else:


### PR DESCRIPTION
There were a couple of changes in the internals of Django which have broken parts of django-refinery.

In django/django@d5a277ba4d608284991428fc3f7d6e0dbe6f8300 `QUERY_TERMS` was changed to be a set. This is backwards compatible if you use the fact iterating over a dictionary is the same as iterating over `dict.keys()`.

In django/django@c4aa26a983c91b1ec015fe0552077847116dfab7 `LOOKUP_SEP` was moved to a different module.

All the tests should now pass on Django1.4 and Django1.5b1.
